### PR TITLE
remove numpy and scipy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 .mypy_cache/
 
 .idea/
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,4 @@ ENV/
 # mypy
 .mypy_cache/
 
-.python-version
-
 .idea/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+1.2.0 (2020-12-17)
+------------------
+
+* Implement Newton-Raphson based solver to approximate IRR
+* Remove dependency on `scipy` and `numpy`
+
 1.1.0 (2020-10-15)
 ------------------
 

--- a/docs/irr.rst
+++ b/docs/irr.rst
@@ -1,19 +1,29 @@
-The internal return rate is effective rate at which the net principal is grows
-in order to exactly match the sum of the due returns.
+The internal return rate is the effective rate at which the net principal
+is grows in order to exactly match the sum of the due returns. The IRR is the
+actual "interest rate" from the point of view of a borrower, who receives
+the net principal but will have to pay off its grossed up value.
 
-Let :math:`s_\circ` be a net principal (i.e., a principal with eventual
-taxes and fees properly deduced), :math:`r_1,r_2\ldots,r_k` a sequence of
-returns and :math:`n_1,n_2,\ldots,n_k` the due days for these returns. The
-*internal return rate* :math:`c` is then determined from the unique positive
-real root of the polynomial
-
-.. math::
-
-    f(X) = s_\circ X^{n_k} - r_k X^{n_k-n_1} - \cdots
-    - r_2 X^{n_k-n_{k-1}} - r_1
-
-on the real unknown
+Let :math:`r_1, r_2,\ldots ,r_k` be the expected returns that will pay
+off the grossed up principal, :math:`n_1, n_2,\ldots, n_k` the number
+of days since the loan was granted until each expected return. If
+:math:`s_\circ` is the net principal, the IRR :math:`c` is defined as
+the least positive real solution of the equation
 
 .. math::
 
-    X = 1 + c.
+    s_\circ (1 + c)^{n_k} - \sum_{i=1}^k r_i (1 + c)^{n_k - n_i} = 0.
+
+Note that this is an algebraic equation on the unknown :math:`1 + c`. Let
+:math:`X = 1 + c` and :math:`f(X)` be the polynomial
+
+.. math::
+
+    f(X) = s_\circ X^{n_k} - r_1 X^{n_k - n_1} - r_2 X^{n_k - n_2}
+    - \cdots - r_k.
+
+Therefore, to approximate the IRR is equivalent to approximate
+a positive real root of :math:`f(X)`. In this library, this is achieved by
+a Newton-Raphson based solver, which is a natural choice since it is easy
+to evaluate the derivative :math:`f^\prime (X)` of :math:`f(X)` and the
+loan's daily interest rate can be adopted as starting point for the
+approximation as we know the IRR is a slightly greater aliquot.

--- a/loan_calculator/grossup/__init__.py
+++ b/loan_calculator/grossup/__init__.py
@@ -1,0 +1,7 @@
+from loan_calculator.grossup.iof import IofGrossup
+from loan_calculator.grossup.base import GrossupType
+
+
+GROSSUP_TYPE_CLASS_MAP = {
+    GrossupType.iof: IofGrossup,
+}

--- a/loan_calculator/grossup/base.py
+++ b/loan_calculator/grossup/base.py
@@ -1,4 +1,11 @@
+from enum import Enum
+
 from loan_calculator.irr import approximate_irr
+
+
+class GrossupType(Enum):
+
+    iof = 'iof'
 
 
 class BaseGrossup(object):

--- a/loan_calculator/grossup/base.py
+++ b/loan_calculator/grossup/base.py
@@ -43,12 +43,13 @@ class BaseGrossup(object):
 
     @property
     def irr(self):
-        """The IRR affecting the net principal."""
+        """Approximation for the IRR affecting the net principal."""
         return approximate_irr(
             self.base_principal,
             self.grossed_up_loan.due_payments,
             [
                 (r_date - self.reference_date).days
                 for r_date in self.base_loan.return_dates
-            ]
+            ],
+            self.base_loan.daily_interest_rate
         )

--- a/loan_calculator/irr.py
+++ b/loan_calculator/irr.py
@@ -1,18 +1,66 @@
-import numpy as np
-from scipy.optimize import fsolve
+def _solve(target_function, lowerbound, upperbound, allowed_error=0.00000001):
+    """Approximate the root of a target function using bisection search.
+
+    Parameters
+    ----------
+
+    target_function: callable, required
+        Python callable accepting a single numerical argument and returning a
+        single numerical valued.
+    lowerbound: float, required
+        Known lowerbound for a root of the target function.
+    upperbound: float, required
+        Known upperbound for a root of the target function.
+    allowed_error: float, optional
+        Maximum allowed error (default is 0.00000001)
+    """
+
+    if lowerbound >= upperbound:
+
+        raise ValueError('must be lowerbound < upperbound')
+
+    if target_function(lowerbound) * target_function(upperbound) >= 0:
+
+        raise ValueError(
+            'target function values must switch sings at the interval limits'
+        )
+
+    current_error_bound = upperbound - lowerbound
+
+    while current_error_bound > allowed_error:
+
+        mid_point = (upperbound + lowerbound) / 2
+
+        if target_function(mid_point) > 0:
+
+            upperbound = mid_point
+
+        else:
+
+            lowerbound = mid_point
+
+        current_error_bound = upperbound - lowerbound
+
+    return lowerbound
 
 
-def approximate_irr(net_principal, returns, return_days):
+def approximate_irr(
+    net_principal,
+    returns,
+    return_days,
+    irr_lowerbound=0,
+    irr_upperbound=10
+):
     """Approximate the internal return rate of a series of returns.
 
-    Wrap around scipy.optimize.solve to approximate the root of a polynomial
-    which is used to defined the internal return rate.
+    Use a bisection solver implementation to approximate the irr for the given
+    parameters.
 
     Let :math:`s_\\circ` be a net principal (i.e., a principal with eventual
     taxes and fees properly deduced), :math:`r_1,r_2\\ldots,r_k` a sequence of
     returns and :math:`n_1,n_2,\\ldots,n_k` the due days for these returns. The
-    *internal return rate* :math:`c` is then determined from the unique
-    positive real root of the polynomial
+    *internal return rate* :math:`c` is then defined as the least positive root
+    of the polynomial
 
     .. math::
 
@@ -24,21 +72,38 @@ def approximate_irr(net_principal, returns, return_days):
     .. math::
 
         X = 1 + c.
+
+    Parameters
+    ----------
+
+    net_principal: float, required
+        The principal used as reference to evaluate the irr, i.e., this is the
+        amount of money which is, from the perspective of the borrower,
+        affected by the irr.
+    returns: list, required
+        List of expected returns or due payments.
+    return_days: list, required
+        List of number of days since the loan was granted until each expected
+        return.
+    irr_lowerbound: float, optional
+        Known lowerbound for the irr. If no bound is provided, the trivial
+        bound 0 is assumed.
+    irr_upperbound: float, optional
+        Known upperbound the irr (default 10.)
     """
 
     r_days = return_days
 
+    coefficients_vec = [net_principal] + [-1 * r for r in returns]
+
     def return_polynomial(irr_):
-        coefficients_vec = np.array(
-            [net_principal] + [-1 * r for r in returns],
-            dtype=float
+
+        powers_vec = [(1 + irr_) ** (r_days[-1] - n) for n in [0] + r_days]
+
+        return sum(
+            coef * power for coef, power in zip(coefficients_vec, powers_vec)
         )
 
-        unknowns_vec = np.array(
-            [(1 + irr_) ** (r_days[-1] - n) for n in [0] + r_days],
-            dtype=float
-        )
-
-        return np.dot(coefficients_vec, unknowns_vec)
-
-    return fsolve(return_polynomial, np.array(0.0))[0]
+    return _solve(
+        return_polynomial, lowerbound=irr_lowerbound, upperbound=irr_upperbound
+    )

--- a/loan_calculator/loan.py
+++ b/loan_calculator/loan.py
@@ -1,10 +1,7 @@
 from datetime import timedelta
 
-from loan_calculator.schedule import (
-    ProgressivePriceSchedule,
-    RegressivePriceSchedule,
-    ConstantAmortizationSchedule,
-)
+from loan_calculator.schedule import SCHEDULE_TYPE_CLASS_MAP
+from loan_calculator.schedule.base import AmortizationScheduleType
 
 
 class Loan(object):
@@ -32,7 +29,7 @@ class Loan(object):
         A discriminator string indicating the amortization schedule to be
         adopted. The available schedules are progressive_price_schedule,
         regressive_price_schedule, constant_amortization_schedule.
-        (default progressive_price_schedule).
+        (default AmortizationScheduleType.progressive_price_schedule.value).
     """
 
     def __init__(
@@ -43,7 +40,9 @@ class Loan(object):
         return_dates,
         year_size=365,
         grace_period=0,
-        amortization_schedule_type='progressive_price_schedule'
+        amortization_schedule_type=(
+            AmortizationScheduleType.progressive_price_schedule.value
+        )
     ):
         """Initialize loan."""
 
@@ -65,19 +64,13 @@ class Loan(object):
         self.year_size = year_size
         self.grace_period = grace_period
 
-        self.amortization_schedule_type = amortization_schedule_type
+        self.amortization_schedule_type = (
+            AmortizationScheduleType(amortization_schedule_type)
+        )
 
-        if amortization_schedule_type == 'progressive_price_schedule':
-            self.amortization_schedule_cls = ProgressivePriceSchedule
-
-        elif amortization_schedule_type == 'regressive_price_schedule':
-            self.amortization_schedule_cls = RegressivePriceSchedule
-
-        elif amortization_schedule_type == 'constant_amortization_schedule':
-            self.amortization_schedule_cls = ConstantAmortizationSchedule
-
-        else:
-            raise TypeError('Unknown amortization schedule type.')
+        self.amortization_schedule_cls = SCHEDULE_TYPE_CLASS_MAP[
+            self.amortization_schedule_type
+        ]
 
         if any(
             self.capitalization_start_date >= r_date

--- a/loan_calculator/projection.py
+++ b/loan_calculator/projection.py
@@ -1,4 +1,4 @@
-from loan_calculator.grossup.iof import IofGrossup
+from loan_calculator.grossup import GrossupType, GROSSUP_TYPE_CLASS_MAP
 
 
 class Projection(object):
@@ -9,16 +9,14 @@ class Projection(object):
     """
 
     def __init__(
-        self, loan, projection_dates, grossup_type='iof', *args
+        self, loan, projection_dates, grossup_type=GrossupType.iof, *args
     ):
 
         self.loan = loan
         self.projection_dates = projection_dates
 
-        if grossup_type == 'iof':
-            self.grossup_cls = IofGrossup
-        else:
-            raise TypeError('Unknown grossup type.')
+        self.grossup_type = GrossupType(grossup_type)
+        self.grossup_cls = GROSSUP_TYPE_CLASS_MAP[self.grossup_type]
 
         self.projections = [
             self.grossup_cls(loan, reference_date, *args)

--- a/loan_calculator/schedule/__init__.py
+++ b/loan_calculator/schedule/__init__.py
@@ -1,8 +1,17 @@
+from .base import AmortizationScheduleType
 from .price import ProgressivePriceSchedule, RegressivePriceSchedule
 from .constant import ConstantAmortizationSchedule
+
+
+SCHEDULE_TYPE_CLASS_MAP = {
+    AmortizationScheduleType.constant_amortization_schedule: ConstantAmortizationSchedule,  # noqa
+    AmortizationScheduleType.regressive_price_schedule: RegressivePriceSchedule,  # noqa
+    AmortizationScheduleType.progressive_price_schedule: ProgressivePriceSchedule,  # noqa
+}
 
 __all__ = [
     'ProgressivePriceSchedule',
     'RegressivePriceSchedule',
-    'ConstantAmortizationSchedule'
+    'ConstantAmortizationSchedule',
+    'SCHEDULE_TYPE_CLASS_MAP',
 ]

--- a/loan_calculator/schedule/base.py
+++ b/loan_calculator/schedule/base.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 class BaseSchedule(object):
     """Base amortization schedule.
 
@@ -34,19 +31,19 @@ class BaseSchedule(object):
         self.return_days = return_days
 
         self.balance = getattr(
-            self, 'calculate_balance', np.zeros(len(return_days) + 1)
+            self, 'calculate_balance', (len(return_days) + 1) * [0]
         )()
 
         self.due_payments = getattr(
-            self, 'calculate_due_payments', np.zeros(len(return_days))
+            self, 'calculate_due_payments', len(return_days) * [0]
         )()
 
         self.interest_payments = getattr(
-            self, 'calculate_interest', np.zeros(len(return_days))
+            self, 'calculate_interest', len(return_days) * [0]
         )()
 
         self.amortizations = getattr(
-            self, 'calculate_amortizations', np.zeros(len(return_days))
+            self, 'calculate_amortizations', len(return_days) * [0]
         )()
 
     def calculate_due_payments(self):
@@ -63,12 +60,12 @@ class BaseSchedule(object):
 
     @property
     def total_paid(self):
-        return np.sum(getattr(self, 'due_payments', 0.0))
+        return sum(getattr(self, 'due_payments', 0.0))
 
     @property
     def total_amortization(self):
-        return np.sum(getattr(self, 'amortizations', 0.0))
+        return sum(getattr(self, 'amortizations', 0.0))
 
     @property
     def total_interest(self):
-        return np.sum(getattr(self, 'interest_payments', 0.0))
+        return sum(getattr(self, 'interest_payments', 0.0))

--- a/loan_calculator/schedule/base.py
+++ b/loan_calculator/schedule/base.py
@@ -1,3 +1,13 @@
+from enum import Enum
+
+
+class AmortizationScheduleType(Enum):
+
+    progressive_price_schedule = 'progressive-price-schedule'
+    regressive_price_schedule = 'regressive-price-schedule'
+    constant_amortization_schedule = 'constant-amortization-schedule'
+
+
 class BaseSchedule(object):
     """Base amortization schedule.
 
@@ -22,6 +32,8 @@ class BaseSchedule(object):
         List of integers representing the number of days since the loan
         was granted until the payments' due dates.
     """
+
+    schedule_type = None
 
     def __init__(self, principal, daily_interest_rate, return_days):
         """Initialize schedule."""

--- a/loan_calculator/schedule/constant.py
+++ b/loan_calculator/schedule/constant.py
@@ -1,4 +1,6 @@
-from loan_calculator.schedule.base import BaseSchedule
+from loan_calculator.schedule.base import (
+    BaseSchedule, AmortizationScheduleType
+)
 
 
 class ConstantAmortizationSchedule(BaseSchedule):
@@ -21,6 +23,8 @@ class ConstantAmortizationSchedule(BaseSchedule):
     - :math:`P_i = A + J_i`.
     - :math:`b_i = s - iA`.
     """
+
+    schedule_type = AmortizationScheduleType.constant_amortization_schedule
 
     def calculate_balance(self):
         """Calculate the balance after each payment.

--- a/loan_calculator/schedule/constant.py
+++ b/loan_calculator/schedule/constant.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from loan_calculator.schedule.base import BaseSchedule
 
 
@@ -40,13 +38,7 @@ class ConstantAmortizationSchedule(BaseSchedule):
 
         k = len(self.return_days)
 
-        return np.array(
-            [
-                self.principal * (1 - float(i) / k)
-                for i in range(k + 1)
-            ],
-            dtype=float
-        )
+        return [self.principal * (1 - float(i) / k) for i in range(k + 1)]
 
     def calculate_amortizations(self):
         """Calculate the amortizations by payments.
@@ -62,13 +54,10 @@ class ConstantAmortizationSchedule(BaseSchedule):
         instalments.
         """
 
-        return np.array(
-            [
-                self.principal / len(self.return_days)
-                for _ in self.return_days
-            ],
-            dtype=float
-        )
+        return [
+            self.principal / len(self.return_days)
+            for _ in self.return_days
+        ]
 
     def calculate_interest(self):
         """Calculate the interest in each payment.
@@ -87,15 +76,12 @@ class ConstantAmortizationSchedule(BaseSchedule):
         # rename variable to make the math more explicit
         d = self.daily_interest_rate
 
-        return np.array(
-            [
-                b * ((1 + d) ** (n - m) - 1)
-                for b, n, m in zip(self.balance[:-1],
-                                   self.return_days,
-                                   [0] + self.return_days[:-1])
-            ],
-            dtype=float
-        )
+        return [
+            b * ((1 + d) ** (n - m) - 1)
+            for b, n, m in zip(self.balance[:-1],
+                               self.return_days,
+                               [0] + self.return_days[:-1])
+        ]
 
     def calculate_due_payments(self):
         """Calculate the due payments.
@@ -120,10 +106,10 @@ class ConstantAmortizationSchedule(BaseSchedule):
         d = self.daily_interest_rate
         k = len(self.return_days)
 
-        return np.array(
-            [b * ((1 + d) ** (n - m) - 1) + p / k
-             for b, n, m in zip(self.balance[:-1],
-                                self.return_days,
-                                [0] + self.return_days[:-1])],
-            dtype=float
-        )
+        return [
+            b * ((1 + d) ** (n - m) - 1) + p / k
+            for b, n, m in zip(
+                self.balance[:-1],
+                self.return_days, [0] + self.return_days[:-1]
+            )
+        ]

--- a/loan_calculator/schedule/price.py
+++ b/loan_calculator/schedule/price.py
@@ -1,5 +1,7 @@
 from loan_calculator.pmt import constant_return_pmt
-from loan_calculator.schedule.base import BaseSchedule
+from loan_calculator.schedule.base import (
+    BaseSchedule, AmortizationScheduleType
+)
 
 
 class BasePriceSchedule(BaseSchedule):
@@ -106,6 +108,8 @@ class ProgressivePriceSchedule(BasePriceSchedule):
       - :math:`A_i = P - J_i`.
     """
 
+    schedule_type = AmortizationScheduleType.progressive_price_schedule
+
     def calculate_interest(self):
         """Calculate interest in each payment.
 
@@ -171,6 +175,8 @@ class RegressivePriceSchedule(BasePriceSchedule):
       - :math:`A_i = \\displaystyle\\frac{P}{(1+d)^{n_i}}`.
       - :math:`J_i = P(1 - \\displaystyle\\frac{P}{(1+d)^{n_i}})`.
     """
+
+    schedule_type = AmortizationScheduleType.regressive_price_schedule
 
     def calculate_amortizations(self):
         """Calculate the amortization due to each payment.

--- a/loan_calculator/schedule/price.py
+++ b/loan_calculator/schedule/price.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from loan_calculator.pmt import constant_return_pmt
 from loan_calculator.schedule.base import BaseSchedule
 
@@ -63,17 +61,14 @@ class BasePriceSchedule(BaseSchedule):
         d = self.daily_interest_rate
         r_days = self.return_days
 
-        return np.array(
-            [
-                (p *
-                 ((1 + d) ** n) *
-                 (1 -
-                  sum(1 / (1 + d) ** m for m in r_days if m <= n) /
-                  sum(1 / (1 + d) ** m for m in r_days)))
-                for n in [0] + r_days
-            ],
-            dtype=float
-        )
+        return [
+            (p *
+             ((1 + d) ** n) *
+             (1 -
+              sum(1 / (1 + d) ** m for m in r_days if m <= n) /
+              sum(1 / (1 + d) ** m for m in r_days)))
+            for n in [0] + r_days
+        ]
 
     def calculate_due_payments(self):
         """Calculate due payments.
@@ -81,10 +76,7 @@ class BasePriceSchedule(BaseSchedule):
         Since this is a Price schedule, all due payments have the same value.
         """
 
-        return np.array(
-            [self.pmt for _ in self.return_days],
-            dtype=float
-        )
+        return [self.pmt for _ in self.return_days]
 
 
 class ProgressivePriceSchedule(BasePriceSchedule):
@@ -128,13 +120,10 @@ class ProgressivePriceSchedule(BasePriceSchedule):
         and :math:`n_1,\\ldots,n_k` are the return days.
         """
 
-        return np.array(
-            [
-                self.pmt * (1.0 - 1.0 / (1 + self.daily_interest_rate) ** n)
-                for n in self.return_days[::-1]
-            ],
-            dtype=float
-        )
+        return [
+            self.pmt * (1.0 - 1.0 / (1 + self.daily_interest_rate) ** n)
+            for n in self.return_days[::-1]
+        ]
 
     def calculate_amortizations(self):
         """Calculate the principal amortization due to each payment.
@@ -150,13 +139,10 @@ class ProgressivePriceSchedule(BasePriceSchedule):
         are the return days and :math:`P=\\mathrm{PMT}(s,d,(n_1,\\ldots,n_k))`.
         """
 
-        return np.array(
-            [
-                self.pmt / (1 + self.daily_interest_rate) ** n
-                for n in self.return_days[::-1]
-            ],
-            dtype=float
-        )
+        return [
+            self.pmt / (1 + self.daily_interest_rate) ** n
+            for n in self.return_days[::-1]
+        ]
 
 
 class RegressivePriceSchedule(BasePriceSchedule):
@@ -202,13 +188,10 @@ class RegressivePriceSchedule(BasePriceSchedule):
         :math:`P = \\mathrm{PMT}(s,d,(n_1,\\ldots,n_k))`
         """
 
-        return np.array(
-            [
-                self.pmt / (1 + self.daily_interest_rate) ** n
-                for n in self.return_days
-            ],
-            dtype=float
-        )
+        return [
+            self.pmt / (1 + self.daily_interest_rate) ** n
+            for n in self.return_days
+        ]
 
     def calculate_interest(self):
         """Calculate the interest in each payment.
@@ -226,10 +209,7 @@ class RegressivePriceSchedule(BasePriceSchedule):
         :math:`P = \\mathrm{PMT}(s,d,(n_1,\\ldots,n_k))`
         """
 
-        return np.array(
-            [
-                self.pmt * (1 - 1.0 / (1 + self.daily_interest_rate) ** n)
-                for n in self.return_days
-            ],
-            dtype=float
-        )
+        return [
+            self.pmt * (1 - 1.0 / (1 + self.daily_interest_rate) ** n)
+            for n in self.return_days
+        ]

--- a/loan_calculator/utils.py
+++ b/loan_calculator/utils.py
@@ -1,4 +1,4 @@
-import numpy as np
+from decimal import Decimal, ROUND_HALF_UP
 
 
 def display_summary(loan, reference_date=None):
@@ -62,8 +62,16 @@ def display_summary(loan, reference_date=None):
             trailing_line,
         ] + [
             body_line.format(
-                *[line[0].isoformat()]
-                + list(map(lambda n: np.round(n, 2), line[1:]))
+                line[0].isoformat(),
+                line[1],
+                *list(
+                    map(
+                        lambda n: Decimal(n).quantize(
+                            Decimal('0.01'),
+                            rounding=ROUND_HALF_UP
+                        ),
+                        line[2:])
+                )
             )
             for line in lines[1:]
         ] + [

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,3 @@ exclude = docs
 
 [aliases]
 test = pytest
-
-[tool:pytest]
-collect_ignore = ['setup.py']

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,6 @@ with open('HISTORY.rst') as history_file:
 with open('LICENSE') as license_file:
     license_ = license_file.read()
 
-requirements = [
-    'numpy',
-    'scipy',
-]
 
 setup_requirements = ['pytest-runner', ]
 
@@ -38,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     description="Loan Calculator",
-    install_requires=requirements,
+    install_requires=[],
     license="MIT license",
     long_description=readme + '\n\n' + history + '\n\n' + license_,
     include_package_data=True,

--- a/tests/grossup/test_grossup_functions.py
+++ b/tests/grossup/test_grossup_functions.py
@@ -1,4 +1,5 @@
-from numpy.testing import assert_almost_equal
+import pytest
+
 from loan_calculator.grossup.functions import (
     br_iof_regressive_price_grossup,
     br_iof_progressive_price_grossup,
@@ -14,7 +15,7 @@ def test_br_progressive_price_grossup_basic_evaluation():
                                            [1, 2],
                                            0.4)
 
-    assert_almost_equal(gup, 2.0, decimal=2)
+    assert gup == pytest.approx(2.0, rel=0.01)
 
 
 def test_br_regressive_price_grossup_basic_evaluation():
@@ -25,7 +26,7 @@ def test_br_regressive_price_grossup_basic_evaluation():
                                           [1, 2],
                                           0.4)
 
-    assert_almost_equal(gup, 2.0, decimal=2)
+    assert gup == pytest.approx(2.0, rel=0.01)
 
 
 def test_br_constant_amortization_grossup_basic_evaluation():
@@ -36,4 +37,4 @@ def test_br_constant_amortization_grossup_basic_evaluation():
                                                [1, 2],
                                                0.49)
 
-    assert_almost_equal(gup, 2.0, decimal=2)
+    assert gup == pytest.approx(2.0, rel=0.01)

--- a/tests/grossup/test_iof_grossup.py
+++ b/tests/grossup/test_iof_grossup.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_almost_equal
+import pytest
 
 from loan_calculator.grossup.iof import IofGrossup
 
@@ -9,15 +9,9 @@ def test_trivial_iof_grossup(loan):
         loan,
         loan.start_date,
         daily_iof_aliquot=0.0,
-        complementary_iof_aliquot=0.0
-        # service_fee_aliquot=0.0
+        complementary_iof_aliquot=0.0,
+        service_fee_aliquot=0.0,
     )
 
-    assert_almost_equal(
-        iof_grossup.grossed_up_principal, loan.principal, decimal=2
-    )
-
-    # In a trivial grossup, the IRR should be equal to the daily interest rate
-    assert_almost_equal(
-        iof_grossup.irr, iof_grossup.base_loan.daily_interest_rate
-    )
+    assert iof_grossup.grossed_up_principal == pytest.approx(loan.principal, rel=0.01)  # noqa
+    assert iof_grossup.irr == pytest.approx(iof_grossup.base_loan.daily_interest_rate, rel=0.01)  # noqa

--- a/tests/grossup/test_iof_tax_functions.py
+++ b/tests/grossup/test_iof_tax_functions.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_almost_equal
+import pytest
 
 from loan_calculator.grossup.iof_tax import (
     amortization_iof,
@@ -9,28 +9,20 @@ from loan_calculator.grossup.iof_tax import (
 
 
 def test_amortization_iof():
-    assert_almost_equal(amortization_iof(100.0, 1, 1.0 / 200), 0.5, decimal=2)
+    assert amortization_iof(100.0, 1, 1.0 / 200) == pytest.approx(0.5, rel=0.01)  # noqa
 
 
 def test_amortization_schedule_iof():
-    assert_almost_equal(
-        amortization_schedule_iof([200.0, 100.0], [1, 2], 1.0 / 200),
-        2.0,
-        decimal=2
-    )
+    assert amortization_schedule_iof([200.0, 100.0], [1, 2], 1.0 / 200) == pytest.approx(2.0, rel=0.01)  # noqa
 
 
 def test_amortization_iof_aliquot_bound():
-    assert_almost_equal(amortization_iof(100.0, 1, 1.0 / 10), 1.5, decimal=2)
+    assert amortization_iof(100.0, 1, 1.0 / 10) == pytest.approx(1.5, rel=2)
 
 
 def test_complementary_iof():
-    assert_almost_equal(complementary_iof(100.0, 0.01), 1.0, decimal=2)
+    assert complementary_iof(100.0, 0.01) == pytest.approx(1.0, rel=0.01)
 
 
 def test_loan_iof():
-    assert_almost_equal(
-        loan_iof(300.0, [100.0, 200.0], [1, 2], 1.0 / 200, 1.0 / 600),
-        3.0,
-        decimal=2
-    )
+    assert loan_iof(300.0, [100.0, 200.0], [1, 2], 1.0 / 200, 1.0 / 600) == pytest.approx(3.0, rel=0.01)  # noqa

--- a/tests/grossup/test_service_fee.py
+++ b/tests/grossup/test_service_fee.py
@@ -1,11 +1,7 @@
-from numpy.testing import assert_almost_equal
+import pytest
 
 from loan_calculator.grossup.service_fee import linear_service_fee
 
 
 def test_linear_service_fee():
-    assert_almost_equal(
-        linear_service_fee(100.0, 0.01),
-        1.0,
-        decimal=2
-    )
+    assert linear_service_fee(100.0, 0.01) == pytest.approx(1.0, rel=0.01)

--- a/tests/schedule/test_constant_schedules.py
+++ b/tests/schedule/test_constant_schedules.py
@@ -1,4 +1,4 @@
-import numpy as np
+import pytest
 
 from loan_calculator.schedule.constant import ConstantAmortizationSchedule
 
@@ -15,23 +15,16 @@ def test_constant_amortization_schedule():
         return_days
     )
 
-    expected_amortizations = np.array([160, 160, 160, 160, 160], dtype=float)
-    expected_balances = np.array([800, 640, 480, 320, 160, 0], dtype=float)
-    expected_interests = np.array([640, 512, 384, 256, 128], dtype=float)
-    expected_payments = np.array([800, 672, 544, 416, 288], dtype=float)
+    expected_amortizations = [160, 160, 160, 160, 160]
+    expected_balances = [800, 640, 480, 320, 160, 0]
+    expected_interests = [640, 512, 384, 256, 128]
+    expected_payments = [800, 672, 544, 416, 288]
 
-    np.testing.assert_almost_equal(
-        schedule.amortizations, expected_amortizations
-    )
+    assert schedule.amortizations == pytest.approx(expected_amortizations, rel=0.01)  # noqa
+    assert schedule.balance == pytest.approx(expected_balances, rel=0.01)
+    assert schedule.interest_payments == pytest.approx(expected_interests, rel=0.01)  # noqa
+    assert schedule.due_payments == pytest.approx(expected_payments, rel=0.01)
 
-    np.testing.assert_almost_equal(schedule.balance, expected_balances)
-
-    np.testing.assert_almost_equal(
-        schedule.interest_payments, expected_interests
-    )
-
-    np.testing.assert_almost_equal(schedule.due_payments, expected_payments)
-
-    np.testing.assert_almost_equal(schedule.total_amortization, principal)
-    np.testing.assert_almost_equal(schedule.total_interest, 1920.00)
-    np.testing.assert_almost_equal(schedule.total_paid, 2720.00)
+    assert schedule.total_amortization == pytest.approx(principal, rel=0.01)
+    assert schedule.total_interest == pytest.approx(1920.00, rel=0.01)
+    assert schedule.total_paid == pytest.approx(2720.00, rel=0.01)

--- a/tests/schedule/test_price_schedules.py
+++ b/tests/schedule/test_price_schedules.py
@@ -1,6 +1,4 @@
-import numpy as np
-from numpy import testing as npt
-
+import pytest
 from loan_calculator.schedule.price import (ProgressivePriceSchedule,
                                             RegressivePriceSchedule)
 
@@ -17,41 +15,33 @@ def test_progressive_price_amortization_schedule():
         return_days
     )
 
-    expected_amortizations = np.array(
-        [744.09, 766.42, 789.41, 813.09, 837.48,
-         862.61, 888.49, 915.14, 942.60, 970.87],
-        dtype=float
-    )
+    expected_amortizations = [
+        744.09, 766.42, 789.41, 813.09, 837.48,
+        862.61, 888.49, 915.14, 942.60, 970.87
+    ]
 
-    expected_balances = np.array(
-        [8530.20, 7786.11, 7019.69, 6230.28, 5417.19,
-         4579.71, 3717.10, 2828.61, 1913.47, 970.87, 0.0],
-        dtype=float
-    )
+    expected_balances = [
+        8530.20, 7786.11, 7019.69, 6230.28, 5417.19,
+        4579.71, 3717.10, 2828.61, 1913.47, 970.87, 0.0
+    ]
 
-    expected_interests = np.array(
-        [255.91, 233.58, 210.59, 186.91, 162.52,
-         137.39, 111.51, 84.86, 57.40, 29.13],
-        dtype=float
-    )
+    expected_interests = [
+        255.91, 233.58, 210.59, 186.91, 162.52,
+        137.39, 111.51, 84.86, 57.40, 29.13
+    ]
 
-    expected_payments = np.array(
-        [1000.00, 1000.00, 1000.00, 1000.00, 1000.00,
-         1000.00, 1000.00, 1000.00, 1000.00, 1000.00],
-        dtype=float
-    )
+    expected_payments = [
+        1000.00, 1000.00, 1000.00, 1000.00, 1000.00,
+        1000.00, 1000.00, 1000.00, 1000.00, 1000.00
+    ]
 
-    npt.assert_almost_equal(schedule.amortizations, expected_amortizations,
-                            decimal=2)
-    npt.assert_almost_equal(schedule.balance, expected_balances, decimal=2)
-    npt.assert_almost_equal(schedule.interest_payments, expected_interests,
-                            decimal=2)
-    npt.assert_almost_equal(schedule.due_payments, expected_payments,
-                            decimal=2)
-
-    npt.assert_almost_equal(schedule.total_amortization, principal, decimal=2)
-    npt.assert_almost_equal(schedule.total_interest, 1469.80, decimal=2)
-    npt.assert_almost_equal(schedule.total_paid, 10000.00, decimal=2)
+    assert schedule.amortizations == pytest.approx(expected_amortizations, rel=0.01)  # noqa
+    assert schedule.balance == pytest.approx(expected_balances, rel=0.01)
+    assert schedule.interest_payments == pytest.approx(expected_interests, rel=0.01)  # noqa
+    assert schedule.due_payments == pytest.approx(expected_payments, rel=0.01)
+    assert schedule.total_amortization == pytest.approx(principal, rel=0.01)
+    assert schedule.total_interest == pytest.approx(1469.80, rel=0.01)
+    assert schedule.total_paid == pytest.approx(10000.00, rel=0.01)
 
 
 def test_regressive_price_amortization_schedule():
@@ -66,38 +56,30 @@ def test_regressive_price_amortization_schedule():
         return_days
     )
 
-    expected_amortizations = np.array(
-        [970.87, 942.6, 915.14, 888.49, 862.61,
-         837.48, 813.09, 789.41, 766.42, 744.09],
-        dtype=float
-    )
+    expected_amortizations = [
+        970.87, 942.6, 915.14, 888.49, 862.61,
+        837.48, 813.09, 789.41, 766.42, 744.09
+    ]
 
-    expected_balances = np.array(
-        [8530.20, 7786.11, 7019.69, 6230.28, 5417.19,
-         4579.71, 3717.10, 2828.61, 1913.47, 970.87, 0.0],
-        dtype=float
-    )
+    expected_balances = [
+        8530.20, 7786.11, 7019.69, 6230.28, 5417.19,
+        4579.71, 3717.10, 2828.61, 1913.47, 970.87, 0.0
+    ]
 
-    expected_interests = np.array(
-        [29.13, 57.4, 84.86, 111.51, 137.39,
-         162.52, 186.91, 210.59, 233.58, 255.91],
-        dtype=float
-    )
+    expected_interests = [
+        29.13, 57.4, 84.86, 111.51, 137.39,
+        162.52, 186.91, 210.59, 233.58, 255.91
+    ]
 
-    expected_payments = np.array(
-        [1000.00, 1000.00, 1000.00, 1000.00, 1000.00,
-         1000.00, 1000.00, 1000.00, 1000.00, 1000.00],
-        dtype=float
-    )
+    expected_payments = [
+        1000.00, 1000.00, 1000.00, 1000.00, 1000.00,
+        1000.00, 1000.00, 1000.00, 1000.00, 1000.00
+    ]
 
-    npt.assert_almost_equal(schedule.amortizations, expected_amortizations,
-                            decimal=2)
-    npt.assert_almost_equal(schedule.balance, expected_balances, decimal=2)
-    npt.assert_almost_equal(schedule.interest_payments, expected_interests,
-                            decimal=2)
-    npt.assert_almost_equal(schedule.due_payments, expected_payments,
-                            decimal=2)
-
-    npt.assert_almost_equal(schedule.total_amortization, principal, decimal=2)
-    npt.assert_almost_equal(schedule.total_interest, 1469.80, decimal=2)
-    npt.assert_almost_equal(schedule.total_paid, 10000.00, decimal=2)
+    assert schedule.amortizations == pytest.approx(expected_amortizations, rel=0.01)  # noqa
+    assert schedule.balance == pytest.approx(expected_balances, rel=0.01)
+    assert schedule.interest_payments == pytest.approx(expected_interests, rel=0.01)  # noqa
+    assert schedule.due_payments == pytest.approx(expected_payments, rel=0.01)
+    assert schedule.total_amortization == pytest.approx(principal, rel=0.01)
+    assert schedule.total_interest == pytest.approx(1469.80, rel=0.01)
+    assert schedule.total_paid == pytest.approx(10000.00, rel=0.01)

--- a/tests/test_irr.py
+++ b/tests/test_irr.py
@@ -1,11 +1,8 @@
-from numpy.testing import assert_almost_equal
+import pytest
 
 from loan_calculator.irr import approximate_irr
 
 
 def test_approximate_irr():
 
-    assert_almost_equal(
-        approximate_irr(1.0, [1.0, 1.0], [1, 2]),
-        0.618033988749895
-    )
+    assert approximate_irr(1.0, [1.0, 1.0], [1, 2]) == pytest.approx(0.618033988749895)  # noqa

--- a/tests/test_irr.py
+++ b/tests/test_irr.py
@@ -5,4 +5,4 @@ from loan_calculator.irr import approximate_irr
 
 def test_approximate_irr():
 
-    assert approximate_irr(1.0, [1.0, 1.0], [1, 2]) == pytest.approx(0.618033988749895)  # noqa
+    assert approximate_irr(1.0, [1.0, 1.0], [1, 2], 0.5) == pytest.approx(0.618033988749895)  # noqa

--- a/tests/test_loan.py
+++ b/tests/test_loan.py
@@ -1,7 +1,6 @@
-from datetime import date
-
 import pytest
-from numpy.testing import assert_almost_equal
+
+from datetime import date
 
 from loan_calculator.loan import Loan
 
@@ -20,37 +19,16 @@ args_ = (
 def test_very_large_year_size():
     """Assert trivial year provides equal amortizations."""
 
-    def _do_assert(schedule):
+    def _do_assert(schedule_):
         loan = Loan(
             *args_,
             year_size=100000,
-            # grace_period=0,
-            amortization_schedule_type=schedule
+            grace_period=0,
+            amortization_schedule_type=schedule_
         )
 
-        assert_almost_equal(
-            [250.0, 250.0, 250.0, 250.0],
-            loan.amortizations,
-            2,
-            'Unexpected amortizations for schedule %s'
-            % schedule,
-        )
-
-        assert_almost_equal(
-            [0.0, 0.0, 0.0, 0.0],
-            loan.interest_payments,
-            2,
-            'Unexpected interests for schedule %s'
-            % schedule
-        )
-
-        assert_almost_equal(
-            loan.due_payments,
-            loan.amortizations,
-            2,
-            'Unexpected payments/amortizations for schedule %s'
-            % schedule
-        )
+        assert loan.amortizations == pytest.approx([250.0, 250.0, 250.0, 250.0], rel=0.01)  # noqa
+        assert loan.amortizations == pytest.approx(loan.amortizations)
 
     for schedule in [
         'progressive_price_schedule',

--- a/tests/test_loan.py
+++ b/tests/test_loan.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import date
 
 from loan_calculator.loan import Loan
-
+from loan_calculator.schedule.base import AmortizationScheduleType
 
 args_ = (
     1000.0,
@@ -30,11 +30,7 @@ def test_very_large_year_size():
         assert loan.amortizations == pytest.approx([250.0, 250.0, 250.0, 250.0], rel=0.01)  # noqa
         assert loan.amortizations == pytest.approx(loan.amortizations)
 
-    for schedule in [
-        'progressive_price_schedule',
-        'regressive_price_schedule',
-        'constant_amortization_schedule',
-    ]:
+    for schedule in AmortizationScheduleType:
 
         _do_assert(schedule)
 
@@ -53,6 +49,6 @@ def test_grace_period_exceeds_loan_start():
 
 def test_unknown_amortization_schedule():
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
 
         Loan(*args_, amortization_schedule_type='foo')

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -5,6 +5,6 @@ from loan_calculator.projection import Projection
 
 def test_exception_raising_on_unknown_grossup_type(loan):
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
 
         Projection(loan, [loan.start_date], grossup_type='unknown')


### PR DESCRIPTION
This PR
* implements a bisection search based solver to evaluate the IRR
* remove dependencies on `numpy` and `scipy`