### PR TITLE
fix: utils.py lines:26-27: remove tolist()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ Contributors
 ------------
 
 * Mateus Yano <yano.mateus@gmail.com>
+* Zdeněk Lapeš <lapes.zdenek@gmail.com>

--- a/loan_calculator/utils.py
+++ b/loan_calculator/utils.py
@@ -23,9 +23,9 @@ def display_summary(loan, reference_date=None):
             map(lambda d: (d - reference_date).days,
                 dates),
             loan.balance,
-            [''] + loan.amortizations.tolist(),
-            [''] + loan.interest_payments.tolist(),
-            [''] + loan.due_payments.tolist(),
+            [''] + loan.amortizations,
+            [''] + loan.interest_payments,
+            [''] + loan.due_payments,
         )
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from datetime import date
+
+from loan_calculator.loan import Loan
+from loan_calculator.utils import display_summary
+from loan_calculator.schedule.base import AmortizationScheduleType
+
+
+def test_this_was_an_error_before():
+    """
+    This was an error before:
+    utils.py:26-27 : display_summary(): - loan.amortizations.tolist(),... (AttributeError: 'list' object has no attribute 'tolist')
+    """
+    loan = Loan(
+        principal=10000.00,  # principal
+        annual_interest_rate=0.05,  # annual interest rate
+        start_date=date(2020, 1, 5),  # start date
+        return_dates=[
+            date(2020, 2, 12),  # expected return date
+            date(2020, 3, 13),  # expected return date
+            date(2020, 3, 11),  # expected return date
+            date(2020, 4, 13),  # expected return date
+            date(2020, 5, 12),  # expected return date
+            date(2020, 6, 12),  # expected return date
+            date(2020, 7, 14),  # expected return date
+            date(2020, 8, 15),  # expected return date
+        ],
+        year_size=365,  # used to convert between annual and daily interest rates # noqa
+        grace_period=0,  # number of days for which the principal is not affected by the interest rate  # noqa
+        amortization_schedule_type=AmortizationScheduleType.progressive_price_schedule, # noqa
+        # determines how the principal is amortized
+    )
+    display_summary(loan)


### PR DESCRIPTION
In utils.py, when calling display_summary(loan), on lines:26-27,  tolist() return AttributeError